### PR TITLE
PAG-COMP : Added inner function to call xml parser.

### DIFF
--- a/cfdiengine/docmaker/builders/pagpdf.py
+++ b/cfdiengine/docmaker/builders/pagpdf.py
@@ -27,10 +27,20 @@ class PagPdf(BuilderGen):
         super().__init__(logger)
 
     def data_acq(self, conn, d_rdirs, **kwargs):
-        pass
+
+        def fetch_info(f):
+            parser = xmlreader.SaxReader()
+            try:
+                return parser(f)
+            except xml.sax.SAXParseException as e:
+                raise DocBuilderStepError("cfdi xml could not be parsed : {}".format(e))
+            except Exception as e:
+
+        return { 'BLA1': "I DO NOT KNOW", "BLA2": 'WHATEVER'}
 
     def format_wrt(self, output_file, dat):
         self.logger.debug('dumping contents of dat: {}'.format(repr(dat)))
+        return
 
 
     def data_rel(self, dat):


### PR DESCRIPTION
The cfdi (xml file) must be parsed in order to fetch
several values from its attributes that perhaps were
not collected and stored into database at the moment
of its inception.

Signed-off-by: Bob Ross <pianodaemon@gmail.com>